### PR TITLE
Add basic directory checking integrity checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build:
 .PHONY: debug
 debug:
 	go build -tags 'debug' $(LDFLAGS) -o $(BINPATH)/dp-integrity-checker
-	HUMAN_LOG=1 DEBUG=1 $(BINPATH)/dp-integrity-checker
+	HUMAN_LOG=1 DEBUG=1 ZEBEDEE_ROOT=${zebedee_root} $(BINPATH)/dp-integrity-checker
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # dp-integrity-checker
+
 Periodic nomad job for checking integrity of zebedee workspace
 
 ### Getting started
@@ -11,8 +12,12 @@ Periodic nomad job for checking integrity of zebedee workspace
 
 ### Configuration
 
-| Environment variable         | Default   | Description
-| ---------------------------- | --------- | -----------
+| Environment variable | Default   | Description                 |
+|----------------------|-----------|-----------------------------|
+| ZEBEDEE_ROOT         | "content" | Root of the zebedee-content |
+
+NB. For developers the zebedee root is usually specified in the lowercase `zebedee_root` env so this service aliases
+this in the `make debug` target to make local development more straightforward.
 
 ### Contributing
 

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -1,0 +1,69 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+	"github.com/ONSdigital/log.go/v2/log"
+	"os"
+	"path"
+	"sync"
+)
+
+// Checker defines a runnable integrity checker
+type Checker struct {
+	mu              sync.Mutex
+	ZebedeeRoot     string
+	Inconsistencies []string
+}
+
+// Result holds final results of an integrity checker run
+type Result struct {
+	Success         bool
+	Inconsistencies []string
+}
+
+// New returns an integrity checker based at the supplied zebedee root
+func New(ctx context.Context, zebedeeRoot string) *Checker {
+	return &Checker{
+		ZebedeeRoot: zebedeeRoot,
+	}
+}
+
+// Run runs the integrity checker
+func (c *Checker) Run(ctx context.Context) (Result, error) {
+	valid := true
+
+	valid = c.validateDir(ctx, "zebedee/master") && valid
+	valid = c.validateDir(ctx, "zebedee/publish-log") && valid
+
+	return Result{
+		Success:         valid,
+		Inconsistencies: c.Inconsistencies,
+	}, nil
+
+}
+
+func (c *Checker) validateDir(ctx context.Context, dir string) bool {
+	root := c.ZebedeeRoot
+	fulldir := path.Join(root, dir)
+	logData := log.Data{
+		"dir": fulldir,
+	}
+	if _, err := os.Stat(fulldir); os.IsNotExist(err) {
+		log.Info(ctx, "dir does not exist in zebedee root", logData)
+		c.AddInconsistency(fmt.Sprintf("'%s' dir missing from zebedee root", dir))
+		return false
+	}
+	log.Info(ctx, "dir exists in zebedee root", logData)
+	return true
+}
+
+func (c *Checker) AddInconsistency(msg string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.Inconsistencies == nil {
+		c.Inconsistencies = make([]string, 0)
+	}
+	c.Inconsistencies = append(c.Inconsistencies, msg)
+}

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -30,32 +30,43 @@ func New(ctx context.Context, zebedeeRoot string) *Checker {
 }
 
 // Run runs the integrity checker
-func (c *Checker) Run(ctx context.Context) (Result, error) {
-	valid := true
+func (c *Checker) Run(ctx context.Context) (*Result, error) {
+	validMaster, err := c.validateDir(ctx, "zebedee/master")
+	if err != nil {
+		return nil, err
+	}
 
-	valid = c.validateDir(ctx, "zebedee/master") && valid
-	valid = c.validateDir(ctx, "zebedee/publish-log") && valid
+	validPublishLog, err := c.validateDir(ctx, "zebedee/publish-log")
+	if err != nil {
+		return nil, err
+	}
 
-	return Result{
+	valid := validMaster && validPublishLog
+
+	return &Result{
 		Success:         valid,
 		Inconsistencies: c.Inconsistencies,
 	}, nil
 
 }
 
-func (c *Checker) validateDir(ctx context.Context, dir string) bool {
+func (c *Checker) validateDir(ctx context.Context, dir string) (bool, error) {
 	root := c.ZebedeeRoot
 	fulldir := path.Join(root, dir)
 	logData := log.Data{
 		"dir": fulldir,
 	}
-	if _, err := os.Stat(fulldir); os.IsNotExist(err) {
+	if _, err := os.Stat(fulldir); err != nil {
+		if !os.IsNotExist(err) {
+			log.Error(ctx, "error reading dir in zebedee root", err, logData)
+			return false, err
+		}
 		log.Info(ctx, "dir does not exist in zebedee root", logData)
 		c.AddInconsistency(fmt.Sprintf("'%s' dir missing from zebedee root", dir))
-		return false
+		return false, nil
 	}
 	log.Info(ctx, "dir exists in zebedee root", logData)
-	return true
+	return true, nil
 }
 
 func (c *Checker) AddInconsistency(msg string) {

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1,0 +1,67 @@
+package checker_test
+
+import (
+	"context"
+	"github.com/ONSdigital/dp-integrity-checker/checker"
+	"os"
+	"path"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestRun_EmptyWorkspace(t *testing.T) {
+	os.Clearenv()
+
+	Convey("Given a checker on an empty directory", t, func() {
+		tempZebedeeRoot, err := os.MkdirTemp("", "checkertest")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(tempZebedeeRoot)
+
+		chk := checker.New(context.Background(), tempZebedeeRoot)
+
+		Convey("When the the checker is run", func() {
+			res, err := chk.Run(context.Background())
+			So(err, ShouldBeNil)
+
+			Convey("Then the results should show missing dirs", func() {
+				So(res, ShouldNotBeNil)
+				So(res.Success, ShouldBeFalse)
+				So(res.Inconsistencies, ShouldHaveLength, 2)
+				So(res.Inconsistencies[0], ShouldResemble, "'zebedee/master' dir missing from zebedee root")
+				So(res.Inconsistencies[1], ShouldResemble, "'zebedee/publish-log' dir missing from zebedee root")
+			})
+		})
+	})
+}
+
+func TestRun_GoodWorkspaceNoCollections(t *testing.T) {
+	os.Clearenv()
+
+	Convey("Given a checker on an valid but empty zebedee workspace", t, func() {
+		tempZebedeeRoot, err := os.MkdirTemp("", "checkertest")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(tempZebedeeRoot)
+
+		addDirs(tempZebedeeRoot, "zebedee/master", "zebedee/publish-log")
+
+		chk := checker.New(context.Background(), tempZebedeeRoot)
+
+		Convey("When the the checker is run", func() {
+			res, err := chk.Run(context.Background())
+			So(err, ShouldBeNil)
+
+			Convey("Then the results should show missing dirs", func() {
+				So(res, ShouldNotBeNil)
+				So(res.Success, ShouldBeTrue)
+				So(res.Inconsistencies, ShouldHaveLength, 0)
+			})
+		})
+	})
+}
+
+func addDirs(ws string, dirs ...string) {
+	for _, dir := range dirs {
+		os.MkdirAll(path.Join(ws, dir), 0750)
+	}
+}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -10,6 +10,28 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+func TestRun_Unreadable(t *testing.T) {
+	os.Clearenv()
+
+	Convey("Given a checker on an unreadable directory", t, func() {
+		tempZebedeeRoot, err := os.CreateTemp("", "checkertest")
+		So(err, ShouldBeNil)
+		defer os.Remove(tempZebedeeRoot.Name())
+
+		chk := checker.New(context.Background(), tempZebedeeRoot.Name())
+
+		Convey("When the the checker is run", func() {
+			res, err := chk.Run(context.Background())
+
+			Convey("Then the checker should return an error", func() {
+				So(res, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "/zebedee/master: not a directory")
+			})
+		})
+	})
+}
+
 func TestRun_EmptyWorkspace(t *testing.T) {
 	os.Clearenv()
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 
 // Config represents service configuration for dp-integrity-checker
 type Config struct {
+	ZebedeeRoot string `envconfig:"ZEBEDEE_ROOT"`
 }
 
 var cfg *Config
@@ -17,7 +18,9 @@ func Get() (*Config, error) {
 		return cfg, nil
 	}
 
-	cfg = &Config{}
+	cfg = &Config{
+		ZebedeeRoot: "content",
+	}
 
 	return cfg, envconfig.Process("", cfg)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,7 +21,9 @@ func TestConfig(t *testing.T) {
 			Convey("Then there should be no error returned, and values are as expected", func() {
 				configuration, err = Get() // This Get() is only called once, when inside this function
 				So(err, ShouldBeNil)
-				So(configuration, ShouldResemble, &Config{})
+				So(configuration, ShouldResemble, &Config{
+					ZebedeeRoot: "content"},
+				)
 			})
 
 			Convey("Then a second call to config should return the same config", func() {

--- a/dp-integrity-checker.nomad
+++ b/dp-integrity-checker.nomad
@@ -4,8 +4,8 @@ job "dp-integrity-checker" {
   type        = "batch"
 
   periodic {
-    cron             = "0 0 1 * * 1-5 *"
-    time_zone = "UTC"
+    cron             = "0 0 1 * * * *"
+    time_zone        = "UTC"
     prohibit_overlap = true
   }
 
@@ -14,7 +14,7 @@ job "dp-integrity-checker" {
 
     constraint {
       attribute = "${node.class}"
-      value     = "publishing"
+      value     = "publishing-mount"
     }
 
     restart {
@@ -37,6 +37,15 @@ job "dp-integrity-checker" {
         args = ["./dp-integrity-checker"]
 
         image = "{{ECR_URL}}:concourse-{{REVISION}}"
+
+        mounts = [
+          {
+            type     = "bind"
+            target   = "/content"
+            source   = "/var/florence"
+            readonly = false
+          }
+        ]
       }
 
       resources {

--- a/main.go
+++ b/main.go
@@ -5,10 +5,11 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/ONSdigital/dp-integrity-checker/config"
-
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/pkg/errors"
+
+	"github.com/ONSdigital/dp-integrity-checker/checker"
+	"github.com/ONSdigital/dp-integrity-checker/config"
 )
 
 const serviceName = "dp-integrity-checker"
@@ -43,11 +44,18 @@ func run(ctx context.Context) error {
 	}
 	log.Info(ctx, "config on startup", log.Data{"config": cfg, "build_time": BuildTime, "git-commit": GitCommit})
 
-	// Create a success channel for completed checker job
-	// providing an error channel for fatal errors
+	chk := checker.New(ctx, cfg.ZebedeeRoot)
+
+	// Run the checker in the background, using a result channel and an error channel for fatal errors
 	errChan := make(chan error, 1)
-	successChan := make(chan bool, 1)
-	successChan <- true // TODO hard-coded for now, this will actually be where the checker gets run
+	resultChan := make(chan checker.Result, 1)
+	go func() {
+		result, err := chk.Run(ctx)
+		if err != nil {
+			errChan <- err
+		}
+		resultChan <- result
+	}()
 
 	// blocks until completion, an os interrupt or a fatal error occurs
 	select {
@@ -55,8 +63,8 @@ func run(ctx context.Context) error {
 		log.Error(ctx, "checker error received", err)
 	case sig := <-signals:
 		log.Info(ctx, "os signal received", log.Data{"signal": sig})
-	case <-successChan:
-		log.Info(ctx, "integrity check complete")
+	case result := <-resultChan:
+		log.Info(ctx, "integrity check complete", log.Data{"Result": result})
 	}
 	return nil // TODO close down the checker and confirm task completion state (err or nil)
 }

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func run(ctx context.Context) error {
 
 	// Run the checker in the background, using a result channel and an error channel for fatal errors
 	errChan := make(chan error, 1)
-	resultChan := make(chan checker.Result, 1)
+	resultChan := make(chan *checker.Result, 1)
 	go func() {
 		result, err := chk.Run(ctx)
 		if err != nil {


### PR DESCRIPTION
### What

Added a basic integrity checker that checks for existence of `master` and `publish-log` in the zebedee workspace.
Also configures the nomad job to run on `publish-mount` (where the zebedee root is located) and to mount this into the docker container in read-only mode.

### How to review

Ensure tests pass and code makes sense. This can be tested locally if you have a valid `zebedee_root` env var pointing to a local zebedee_content dir by simply running `make debug`.

### Who can review

Anyone but me