### PR TITLE
Add link to integrity checker ops doc

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20.3
+    tag: 1.20.4
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20.3
+    tag: 1.20.4
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.19.5
+    tag: 1.20.4
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20.3
+    tag: 1.20.4
 
 inputs:
   - name: dp-integrity-checker

--- a/notification/slack.go
+++ b/notification/slack.go
@@ -41,6 +41,8 @@ func (n *SlackNotifier) SendCheckerResult(ctx context.Context, result *checker.R
 		attachmentText.WriteRune('\n')
 	}
 
+	attachmentText.WriteString("Please refer to <https://github.com/ONSdigital/dp-operations/blob/main/alerts/IntegrityChecker.md|IntegrityChecker> solution to fix this issue.")
+
 	attachment := slack.Attachment{
 		Pretext: fmt.Sprintf("Found %d inconsistencies during integrity check\n", len(result.Inconsistencies)),
 		Text:    attachmentText.String(),


### PR DESCRIPTION
### What

- Added a link to integrity checker alerts to the dp-operations document on resolving the alert.
- Upgraded go to 1.20.4

### How to review

Check code is good and tests pass etc.

### Who can review

Anyone but me