### PR TITLE
Make content dir mount readonly

### DIFF
--- a/dp-integrity-checker.nomad
+++ b/dp-integrity-checker.nomad
@@ -43,7 +43,7 @@ job "dp-integrity-checker" {
             type     = "bind"
             target   = "/content"
             source   = "/var/florence"
-            readonly = false
+            readonly = true
           }
         ]
       }


### PR DESCRIPTION
### What

Zebedee content dir should be mounted readonly in the integrity checker

### How to review

Ensure config change makes sense. Note this is a nomad deployment change so will be tested in sandbox (it has already been tested via manual modification in the sandbox nomad console).

### Who can review

Anyone