### PR TITLE
Periodic job now hourly during the day

### DIFF
--- a/dp-integrity-checker.nomad
+++ b/dp-integrity-checker.nomad
@@ -4,7 +4,7 @@ job "dp-integrity-checker" {
   type        = "batch"
 
   periodic {
-    cron             = "0 0 1 * * * *"
+    cron             = "0 45 1,6-18 * * * *"
     time_zone        = "UTC"
     prohibit_overlap = true
   }


### PR DESCRIPTION
### What

Changed the cron parameter for the periodic job so it runs hourly through the day instead of just overnight. This will help with debugging integrity check failures such as that on 4th Dec 2023. Moved it to 45mins past the hour so it doesn't clash with 7:00/9:30 publishing.
- 1:45
- 6:45 - 18:45

### How to review

Check change is valid as per https://github.com/hashicorp/cronexpr#implementation

### Who can review

Anyone