### PR TITLE
Upgrade to use go 1.26.3

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-integrity-checker


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4951

The version of go has been increased from 1.26.2 to 1.26.3, to fix audit failures.

### How to review

Sense check. Tests pass.

### Who can review

Anyone.