### PR TITLE
Release 1.6.0

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-integrity-checker

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-integrity-checker


### PR DESCRIPTION
### What

These are the changes in this release:

- Upgrade to use go 1.26.3 - https://github.com/ONSdigital/dp-integrity-checker/pull/30 - @cookel2 
- Upgrade go to 1.26.4 - https://github.com/ONSdigital/dp-integrity-checker/pull/31 - @cookel2 

### How to review

Check only expected commits present and tests pass.

### Who can review

Anyone.